### PR TITLE
Fix fruits not dropping on tree burn

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -352,6 +352,33 @@ public class PlantsListener implements Listener {
             e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), item);
         }
     }
+    
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockBurn(BlockBurnEvent e) {
+        if (!Slimefun.getWorldSettingsService().isWorldEnabled(e.getBlock().getWorld())) {
+            return;
+        }
+
+        String id = BlockStorage.checkID(e.getBlock());
+
+        if (id != null) {
+            for (Berry berry : ExoticGarden.getBerries()) {
+                if (id.equalsIgnoreCase(berry.getID())) {
+                    e.setCancelled(true);
+                    return;
+                }
+            }
+        }
+
+        dropFruitFromTree(e.getBlock());
+        ItemStack item = BlockStorage.retrieve(e.getBlock());
+
+        if (item != null) {
+            e.setCancelled(true);
+            e.getBlock().setType(Material.AIR);
+            e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), item);
+        }
+    }
 
     @EventHandler
     public void onInteract(PlayerInteractEvent e) {


### PR DESCRIPTION
Fruits would not drop when a tree got burned, they would just float in place, this fixes that.